### PR TITLE
Changes from demo comments and other required improvemements

### DIFF
--- a/spark-perf/README.md
+++ b/spark-perf/README.md
@@ -1,0 +1,75 @@
+# Spark-perf benchmark setup
+### Set passwordless login
+
+To create user
+```
+sudo adduser testuser
+sudo adduser testuser sudo
+```
+
+For local host
+
+```
+ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa 
+cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 0600 ~/.ssh/authorized_keys
+ ```
+For other hosts
+
+```
+ssh-copy-id -i ~/.ssh/id_rsa.pub user@host
+ssh user@host
+```
+
+### Pre-requisities:
+1. JAVA Setup should be completed and JAVA_HOME should be set in the ~/.bashrc file (environment variable).
+2. Make sure the nodes are set for password-less SSH both ways(master->slaves).
+3. Since we use the environment variables a lot in our scripts, make sure to comment out the portion following this statement in your ~/.bashrc , 
+`If not running interactively, don't do anything`. Update .bashrc
+
+ Delete/comment the following check.
+  ```
+   # If not running interactively, don't do anything
+   case $- in
+       *i*) ;;
+         *) return;;
+   esac
+  ```
+4. Same username/useraccount should be need on `master` and `slaves` nodes for multinode installation.
+
+### Installations:
+
+* To automate hadoop installation follows the steps,
+
+  ```bash
+  git clone https://github.com/nkalband/Spark-perf-automation.git
+  
+  cd spark-perf-automation
+ 
+  ```
+    
+* Configuration
+
+   1. Hadoop setup is already completed using scripts at https://github.com/kmadhugit/hadoop-cluster-utils.git  and it is running on master & slave machines.
+   2.To configure `spark-perf`, run `./autogen_sparkperf.sh` which will create `config.sh` with appropriate field values.
+   3. User can enter SLAVEIPs (if more than one, use comma seperated) interactively while running `./autogen.sh` file.
+   4. Default `Spark-2.0.1` and `Hadoop-2.7.1` version available for installation. 
+   5. Before executing `./setup_sparkperf.sh` file, user can verify or edit `config.sh` 
+   6. Once setup script completed,source `~/.bashrc` file to export updated spark environment variables for current login session. 
+   
+  ```
+ 
+* Spark web Address
+  
+  Spark            : http://localhost:8080 (Default)
+  ```
+ 
+* Useful scripts
+ 
+  ```
+   > stop-all.sh #stop spark
+   > start-all.sh #start spark
+   > CP <localpath to file> <remotepath to dir> #Copy file from name nodes to all slaves
+   > AN <command> #execute a given command in all nodes including master
+   > DN <command> #execute a given command in all nodes excluding master
+   ```

--- a/spark-perf/README.md
+++ b/spark-perf/README.md
@@ -1,75 +1,26 @@
 # Spark-perf benchmark setup
-### Set passwordless login
 
-To create user
-```
-sudo adduser testuser
-sudo adduser testuser sudo
-```
+### Pre-requisites:
+1. Zip is installed on master machine 
+2. Hadoop and spark setup is already completed using scripts at https://github.com/kmadhugit/hadoop-cluster-utils.git  and it is running on master & slave machines.
 
-For local host
-
-```
-ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa 
-cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-chmod 0600 ~/.ssh/authorized_keys
- ```
-For other hosts
-
-```
-ssh-copy-id -i ~/.ssh/id_rsa.pub user@host
-ssh user@host
-```
-
-### Pre-requisities:
-1. JAVA Setup should be completed and JAVA_HOME should be set in the ~/.bashrc file (environment variable).
-2. Make sure the nodes are set for password-less SSH both ways(master->slaves).
-3. Since we use the environment variables a lot in our scripts, make sure to comment out the portion following this statement in your ~/.bashrc , 
-`If not running interactively, don't do anything`. Update .bashrc
-
- Delete/comment the following check.
-  ```
-   # If not running interactively, don't do anything
-   case $- in
-       *i*) ;;
-         *) return;;
-   esac
-  ```
-4. Same username/useraccount should be need on `master` and `slaves` nodes for multinode installation.
 
 ### Installations:
 
-* To automate hadoop installation follows the steps,
+* To automate SPARK-PERF installation follows below steps,
 
   ```bash
-  git clone https://github.com/nkalband/Spark-perf-automation.git
+  git clone https://github.com/kavanabhat/Spark-Benchmarks-Setup.git
   
-  cd spark-perf-automation
+  cd Spark-Benchmarks-Setup/spark-perf
  
   ```
     
 * Configuration
 
-   1. Hadoop setup is already completed using scripts at https://github.com/kmadhugit/hadoop-cluster-utils.git  and it is running on master & slave machines.
-   2.To configure `spark-perf`, run `./autogen_sparkperf.sh` which will create `config.sh` with appropriate field values.
-   3. User can enter SLAVEIPs (if more than one, use comma seperated) interactively while running `./autogen.sh` file.
-   4. Default `Spark-2.0.1` and `Hadoop-2.7.1` version available for installation. 
-   5. Before executing `./setup_sparkperf.sh` file, user can verify or edit `config.sh` 
-   6. Once setup script completed,source `~/.bashrc` file to export updated spark environment variables for current login session. 
-   
+   1. To configure `spark-perf`, run `./autogen_sparkperf.sh` which will create `config` with appropriate field values considering existing hadoop and spark setup.It will ask for options to select type of test to be run and scale factor.
+   2. Before executing `./setup_sparkperf.sh` file, user can verify or edit `config` 
+   3. Run `./setup_sparkperf.sh` to execute bechmark run for selected tests
+      
   ```
- 
-* Spark web Address
-  
-  Spark            : http://localhost:8080 (Default)
-  ```
- 
-* Useful scripts
- 
-  ```
-   > stop-all.sh #stop spark
-   > start-all.sh #start spark
-   > CP <localpath to file> <remotepath to dir> #Copy file from name nodes to all slaves
-   > AN <command> #execute a given command in all nodes including master
-   > DN <command> #execute a given command in all nodes excluding master
-   ```
+

--- a/spark-perf/autogen_sparkperf.sh
+++ b/spark-perf/autogen_sparkperf.sh
@@ -1,127 +1,94 @@
 #!/bin/bash -l
 
-echo -e '#Master Details' > config.sh
-MASTER=`ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":"`
-echo -e 'MASTER='$MASTER'\n' >> config.sh
+echo -e 'Node server details for existing hadoop and spark setup \n' 
+echo -e '#Master details' > config
+MASTER=`hostname`
+echo -e 'MASTER='$MASTER'' | tee -a config
 
-echo -e 'Please enter slave IP detail in format slave1IP,slave2IP'
-read SLAVEIP
+echo -e '#Slave details of existing hadoop and spark setup' >> config
+SLAVES=`cat ${HADOOP_CONF_DIR}/slaves | tr '\n' ','| sed 's/\,$//'`
 
-j=0
-for i in `echo $SLAVEIP |tr ',' ' '`
-do
-slaveip=$(ssh $i /sbin/ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":")
+echo -e 'SLAVES='$SLAVES'' | tee -a config
 
-if [ $j -eq 0 ]
+echo -e '#spark perf git repository url' >> config
+
+sparkversion=`echo $SPARK_HOME | cut -f2 -d "=" | cut -f4 -d "/" | cut -f2 -d "-"` 2>/dev/null
+
+if [ ${sparkversion:0:1} == 2 ]
 then
-SLAVE=${slaveip}
+	SPARK_PERF_GIT_URL="https://github.com/a-roberts/spark-perf"
+    echo -e 'SPARK_PERF_GIT_URL='$SPARK_PERF_GIT_URL' \n' >> config
 else
-SLAVE=`echo ''${SLAVE}'%'${slaveip}''`
-fi
-((j=j+1))
-done
-
-echo -e '#Slave Details' >> config.sh
-echo -e 'SLAVES='$SLAVE'\n' >> config.sh
-
-echo -e
-echo -n "Please enter Spark version : "
-read -n 5 sparkver
-echo -e "\nFor Spark Version: $sparkver"
-if [ ${sparkver:0:1} == 2 ]
-then
-  echo -e "Available hadoop versions: 1.2.1, 2.5.2, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5, 2.7.0, 2.7.1, 2.7.2, 2.7.3 "
-  echo -e "Please enter Hadoop version (Above versions are compatibility with spark-2.0.0 and later): "
-  read -n 5 hadoopver
-  echo -e 
-elif [ ${sparkver:0:1} -lt 2 ]
-then 
-  echo -e "available hadoop versions: 1.2.1, 2.5.2, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5 "
-  echo -e "Please enter Hadoop version (less than 2.7.0 which are compatibility with below spark-2.0.0) : "
-  read -n 5 hadoopver
-  echo -e 
+    
+	SPARK_PERF_GIT_URL="https://github.com/databricks/spark-perf.git"
+    echo -e 'SPARK_PERF_GIT_URL='$SPARK_PERF_GIT_URL' \n' >> config 
 fi
 
-echo -e '#Hadoop and Spark versions ' >> config.sh
-echo -e 'sparkver='"$sparkver"'' >> config.sh
-echo -e 'hadoopver='"$hadoopver"'\n' >> config.sh
-
-echo -e '#Hadoop and Spark setup zip download urls' >> config.sh
-
-HADOOP_URL="http://www-us.apache.org/dist/hadoop/common/hadoop-${hadoopver}/hadoop-${hadoopver}.tar.gz"
-SPARK_URL="http://www-us.apache.org/dist/spark/spark-${sparkver}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz"
-
-echo -e 'SPARK_URL='$SPARK_URL'' >> config.sh
-echo -e 'HADOOP_URL='$HADOOP_URL'\n' >> config.sh
-
-echo -e '#spark perf git repository urln' >> config.sh
-
-SPARK_PERF_GIT_URL="https://github.com/a-roberts/spark-perf"
-
-echo -e "SPARK_PERF_GIT_URL='$SPARK_PERF_GIT_URL' \n" >> config.sh
-
 echo -e
-echo "Please choose the option for types of tests you want to run"
-echo "#Types tests selected to run" >> config.sh
+echo "Please choose the Y/N option for types of tests you want to run"
+echo "#Types of tests selected to run" >> config
 read -p "Do you wish to run RUN_SPARK_TESTS test ? [y/N] " prompt
 if [[ $prompt == "n" || $prompt == "N" ]]
 then
-    echo -e 'RUN_SPARK_TESTS=False' >> config.sh
-    echo -e 'PREP_SPARK_TESTS=False' >> config.sh
+    echo -e 'RUN_SPARK_TESTS=False' >> config
+    echo -e 'PREP_SPARK_TESTS=False' >> config
 else 
-    echo -e 'RUN_SPARK_TESTS=True' >> config.sh
-    echo -e 'PREP_SPARK_TESTS=True' >> config.sh
+    echo -e 'RUN_SPARK_TESTS=True' >> config
+    echo -e 'PREP_SPARK_TESTS=True' >> config
 fi
-echo -e >> config.sh
+
+echo -e >> config
 read -p "Do you wish to run RUN_PYSPARK_TESTS test ? [y/N] " prompt
 if [[ $prompt == "y" || $prompt == "Y" ]]
 then
-    echo -e 'RUN_PYSPARK_TESTS=True' >> config.sh
-    echo -e 'PREP_PYSPARK_TESTS=True' >> config.sh
+    echo -e 'RUN_PYSPARK_TESTS=True' >> config
+    echo -e 'PREP_PYSPARK_TESTS=True' >> config
 else 
-    echo -e 'RUN_PYSPARK_TESTS=False' >> config.sh
-    echo -e 'PREP_PYSPARK_TESTS=False' >> config.sh
+    echo -e 'RUN_PYSPARK_TESTS=False' >> config
+    echo -e 'PREP_PYSPARK_TESTS=False' >> config
 fi
-echo -e >> config.sh
+
+echo -e >> config
 read -p "Do you wish to run RUN_STREAMING_TESTS test ? [y/N] " prompt
 if [[ $prompt == "y" || $prompt == "Y" ]]
 then
-    echo -e 'RUN_STREAMING_TESTS=True' >> config.sh
-    echo -e 'PREP_STREAMING_TESTS=True' >> config.sh
+    echo -e 'RUN_STREAMING_TESTS=True' >> config
+    echo -e 'PREP_STREAMING_TESTS=True' >> config
 else 
-    echo -e 'RUN_STREAMING_TESTS=False' >> config.sh
-    echo -e 'PREP_STREAMING_TESTS=False' >> config.sh	
+    echo -e 'RUN_STREAMING_TESTS=False' >> config
+    echo -e 'PREP_STREAMING_TESTS=False' >> config	
 fi
-echo -e >> config.sh
+
+echo -e >> config
 read -p "Do you wish to run RUN_MLLIB_TESTS test ? [y/N] " prompt
 if [[ $prompt == "y" || $prompt == "Y" ]]
 then
-    echo -e 'RUN_MLLIB_TESTS=True' >> config.sh
-    echo -e 'PREP_MLLIB_TESTS=True' >> config.sh
-	echo -e 'RUN_PYTHON_MLLIB_TESTS=True' >> config.sh
+    echo -e 'RUN_MLLIB_TESTS=True' >> config
+    echo -e 'PREP_MLLIB_TESTS=True' >> config
+	echo -e 'RUN_PYTHON_MLLIB_TESTS=True' >> config
 else 
-    echo -e 'RUN_MLLIB_TESTS=False' >> config.sh
-    echo -e 'PREP_MLLIB_TESTS=False' >> config.sh
-	echo -e 'RUN_PYTHON_MLLIB_TESTS=False' >> config.sh	
+    echo -e 'RUN_MLLIB_TESTS=False' >> config
+    echo -e 'PREP_MLLIB_TESTS=False' >> config
+	echo -e 'RUN_PYTHON_MLLIB_TESTS=False' >> config	
 		
 fi
 
-echo -e >> config.sh
+echo -e >> config
 echo -e
-echo "#Scale Factor selected for run" >> config.sh
+
+echo "#Scale Factor selected for run" >> config
 read -p "Do you wish to change scaling factor? [y/N] " prompt
 if [[ $prompt == "y" || $prompt == "Y" ]]
 then
-    echo "Please enter the value [0.001/0.1/0.25/0.5/0.75] "
+    echo "Please enter the value [e.g. - 0.001/0.1/0.25/0.5/0.75]"
     read scale
-	echo -e 'SCALE_FACTOR='${scale}'' >> config.sh
+	echo -e 'SCALE_FACTOR='${scale}'' >> config
 else 
     scale=1
-	echo -e 'SCALE_FACTOR='${scale}'' >> config.sh
+	echo -e 'SCALE_FACTOR='${scale}'' >> config
 fi
 
-echo -e 'Please check configuration (config.sh file) once before run (setup.sh file).'
-echo -e 'You can modify hadoop or spark versions in config.sh file'
+echo -e 'Please check configuration (config file) once before run (setup_sparkperf.sh file).'
+echo -e 'You can modify selected values in config file.'
 echo -e
-chmod +x config.sh
-
+chmod +x config

--- a/spark-perf/autogen_sparkperf.sh
+++ b/spark-perf/autogen_sparkperf.sh
@@ -1,0 +1,127 @@
+#!/bin/bash -l
+
+echo -e '#Master Details' > config.sh
+MASTER=`ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":"`
+echo -e 'MASTER='$MASTER'\n' >> config.sh
+
+echo -e 'Please enter slave IP detail in format slave1IP,slave2IP'
+read SLAVEIP
+
+j=0
+for i in `echo $SLAVEIP |tr ',' ' '`
+do
+slaveip=$(ssh $i /sbin/ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":")
+
+if [ $j -eq 0 ]
+then
+SLAVE=${slaveip}
+else
+SLAVE=`echo ''${SLAVE}'%'${slaveip}''`
+fi
+((j=j+1))
+done
+
+echo -e '#Slave Details' >> config.sh
+echo -e 'SLAVES='$SLAVE'\n' >> config.sh
+
+echo -e
+echo -n "Please enter Spark version : "
+read -n 5 sparkver
+echo -e "\nFor Spark Version: $sparkver"
+if [ ${sparkver:0:1} == 2 ]
+then
+  echo -e "Available hadoop versions: 1.2.1, 2.5.2, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5, 2.7.0, 2.7.1, 2.7.2, 2.7.3 "
+  echo -e "Please enter Hadoop version (Above versions are compatibility with spark-2.0.0 and later): "
+  read -n 5 hadoopver
+  echo -e 
+elif [ ${sparkver:0:1} -lt 2 ]
+then 
+  echo -e "available hadoop versions: 1.2.1, 2.5.2, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5 "
+  echo -e "Please enter Hadoop version (less than 2.7.0 which are compatibility with below spark-2.0.0) : "
+  read -n 5 hadoopver
+  echo -e 
+fi
+
+echo -e '#Hadoop and Spark versions ' >> config.sh
+echo -e 'sparkver='"$sparkver"'' >> config.sh
+echo -e 'hadoopver='"$hadoopver"'\n' >> config.sh
+
+echo -e '#Hadoop and Spark setup zip download urls' >> config.sh
+
+HADOOP_URL="http://www-us.apache.org/dist/hadoop/common/hadoop-${hadoopver}/hadoop-${hadoopver}.tar.gz"
+SPARK_URL="http://www-us.apache.org/dist/spark/spark-${sparkver}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz"
+
+echo -e 'SPARK_URL='$SPARK_URL'' >> config.sh
+echo -e 'HADOOP_URL='$HADOOP_URL'\n' >> config.sh
+
+echo -e '#spark perf git repository urln' >> config.sh
+
+SPARK_PERF_GIT_URL="https://github.com/a-roberts/spark-perf"
+
+echo -e "SPARK_PERF_GIT_URL='$SPARK_PERF_GIT_URL' \n" >> config.sh
+
+echo -e
+echo "Please choose the option for types of tests you want to run"
+echo "#Types tests selected to run" >> config.sh
+read -p "Do you wish to run RUN_SPARK_TESTS test ? [y/N] " prompt
+if [[ $prompt == "n" || $prompt == "N" ]]
+then
+    echo -e 'RUN_SPARK_TESTS=False' >> config.sh
+    echo -e 'PREP_SPARK_TESTS=False' >> config.sh
+else 
+    echo -e 'RUN_SPARK_TESTS=True' >> config.sh
+    echo -e 'PREP_SPARK_TESTS=True' >> config.sh
+fi
+echo -e >> config.sh
+read -p "Do you wish to run RUN_PYSPARK_TESTS test ? [y/N] " prompt
+if [[ $prompt == "y" || $prompt == "Y" ]]
+then
+    echo -e 'RUN_PYSPARK_TESTS=True' >> config.sh
+    echo -e 'PREP_PYSPARK_TESTS=True' >> config.sh
+else 
+    echo -e 'RUN_PYSPARK_TESTS=False' >> config.sh
+    echo -e 'PREP_PYSPARK_TESTS=False' >> config.sh
+fi
+echo -e >> config.sh
+read -p "Do you wish to run RUN_STREAMING_TESTS test ? [y/N] " prompt
+if [[ $prompt == "y" || $prompt == "Y" ]]
+then
+    echo -e 'RUN_STREAMING_TESTS=True' >> config.sh
+    echo -e 'PREP_STREAMING_TESTS=True' >> config.sh
+else 
+    echo -e 'RUN_STREAMING_TESTS=False' >> config.sh
+    echo -e 'PREP_STREAMING_TESTS=False' >> config.sh	
+fi
+echo -e >> config.sh
+read -p "Do you wish to run RUN_MLLIB_TESTS test ? [y/N] " prompt
+if [[ $prompt == "y" || $prompt == "Y" ]]
+then
+    echo -e 'RUN_MLLIB_TESTS=True' >> config.sh
+    echo -e 'PREP_MLLIB_TESTS=True' >> config.sh
+	echo -e 'RUN_PYTHON_MLLIB_TESTS=True' >> config.sh
+else 
+    echo -e 'RUN_MLLIB_TESTS=False' >> config.sh
+    echo -e 'PREP_MLLIB_TESTS=False' >> config.sh
+	echo -e 'RUN_PYTHON_MLLIB_TESTS=False' >> config.sh	
+		
+fi
+
+echo -e >> config.sh
+echo -e
+echo "#Scale Factor selected for run" >> config.sh
+read -p "Do you wish to change scaling factor? [y/N] " prompt
+if [[ $prompt == "y" || $prompt == "Y" ]]
+then
+    echo "Please enter the value [0.001/0.1/0.25/0.5/0.75] "
+    read scale
+	echo -e 'SCALE_FACTOR='${scale}'' >> config.sh
+else 
+    scale=1
+	echo -e 'SCALE_FACTOR='${scale}'' >> config.sh
+fi
+
+echo -e 'Please check configuration (config.sh file) once before run (setup.sh file).'
+echo -e 'You can modify hadoop or spark versions in config.sh file'
+echo -e
+chmod +x config.sh
+

--- a/spark-perf/setup_sparkperf.sh
+++ b/spark-perf/setup_sparkperf.sh
@@ -1,199 +1,143 @@
 #!/bin/bash -l
 
-CURDIR=`pwd`            
+PERFUTILS_DIR=`pwd`            
 WORKDIR=${HOME}   
 
 current_time=$(date +"%Y.%m.%d.%S")
 
-if [ ! -d spark_perf_logs ];
+if [ ! -d ${PERFUTILS_DIR}/spark_perf_logs ];
 then
-    mkdir spark_perf_logs
+    mkdir ${PERFUTILS_DIR}/spark_perf_logs
 fi
 
-log=`pwd`/spark_perf_logs/spark_perf_$current_time.log
+log=${PERFUTILS_DIR}/spark_perf_logs/spark_perf_$current_time.log
 
 echo -e | tee -a $log
 
-#check for prerequisites
+#check for zip installed or not
+if [ ! -x /usr/bin/zip ] ; then
+   echo "zip is not installed on Master, so getting installed" | tee -a $log
+   sudo apt-get install zip | tee -a $log
+fi
 
-#Checking if JAVA_HOME set
-if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]
+#checking if config file is created in required format
+
+if [ -f ${PERFUTILS_DIR}/config ]; 
 then
-    echo JAVA_HOME found on MASTER, java executable in $JAVA_HOME | tee $log
-    echo "---------------------------------------------" | tee -a $log
-else
-    echo "JAVA_HOME not found in your environment, please set the JAVA_HOME variable in your environment then continue to run this script." | tee -a $log
-    exit 1 
-fi
-
-#Checking if below line commented in .bashrc
-grep '#case $- in' $HOME/.bashrc &>>/dev/null
- if [ $? -ne 0 ]
-then
-    grep 'case $- in' $HOME/.bashrc &>>/dev/null
-	if [ $? -eq 0 ]
-	then 
-        echo 'Prerequisite not completed on Master. Please comment below lines in .bashrc file , also make sure same on slave machines' | tee -a $log
-        echo "# If not running interactively, don't do anything" | tee -a $log
-        echo "case \$- in" | tee -a $log
-        echo "*i*) ;;" | tee -a $log
-        echo "*) return;;" | tee -a $log
-        echo "esac" | tee -a $log
-	    exit 1
-	fi	
-fi
-
-##Checking if wget and curl installed or not, and getting installed if not
-
-if [ ! -x /usr/bin/wget ] ; then
-   echo "wget is not installed on Master, so getting installed" | tee -a $log
-   sudo apt-get install wget | tee -a $log
-else
-   echo "wget is already installed on Master" | tee -a $log
-fi
-
-if [ ! -x /usr/bin/curl ] ; then
-   echo "curl is not installed on Master, so getting installed" | tee -a $log
-   sudo apt-get install curl | tee -a $log
-else
-   echo "curl is already installed on Master" | tee -a $log
-fi
-
-#checking if config.sh file is created in required format
-
-if [ -f ${CURDIR}/config.sh ]; 
-then
-    ## First time permission set for config.sh file
-    chmod +x ${CURDIR}/config.sh
-    source ${CURDIR}/config.sh
+    ## First time permission set for config file
+    chmod +x ${PERFUTILS_DIR}/config
+    source ${PERFUTILS_DIR}/config
  
     ## Checking config file for all required fields
   
-    { cat ${CURDIR}/config.sh; echo; } | while read -r line; do
+    { cat ${PERFUTILS_DIR}/config; echo; } | while read -r line; do
       if [[ $line =~ "=" ]] ;
       then
           confvalue=`echo $line |grep = | cut -d "=" -f2`
           if [[ -z "$confvalue" ]];
           then
-              echo "Configuration value not set properly for $line, please check config.sh file" | tee -a $log
+              echo "Configuration value not set properly for $line, please check config file" | tee -a $log
               exit 1
           fi
       fi
     done
 	
-	SERVERS=$SLAVES
+	#check if atleast 1 type of test is selected
+	grep "_TEST" ${PERFUTILS_DIR}/config | grep "=True" &>>/dev/null
+	if [ $? -ne 0 ]
+	then
+	    echo 'Please selct atleast one type of test to run spark-perf benchamrk' | tee -a $log
+		exit 1
+	fi
 	
+	#Logic to create server list 
+    cat ${PERFUTILS_DIR}/config | grep SLAVES | grep -v "^#" | tr "," "\n" | grep "$MASTER" &>>/dev/null
+    if [ $? -eq 0 ]
+    then
+	    #if master is also used as data machine 
+        SERVERS=$SLAVES
+    else
+        SERVERS=`echo ''$MASTER'%'$SLAVES''`
+    fi
+		
 	cd ${WORKDIR}
 	
-	# Spark setup steps
-    if [ ! -f ${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz ];
-    then
-        if curl --output /dev/null --silent --head --fail $SPARK_URL
-        then
-	        echo 'SPARK file Downloading on Master - '$MASTER'' | tee -a $log
-            wget $SPARK_URL | tee -a $log
-        else 
-            echo 'This URL '${SPARK_URL}' does not exist. Please check your spark version then continue to run this script.' | tee -a $log
-        exit 1
-        fi 
-	 
-    echo "***********************************************"
-    fi
-	
-	for i in `echo $SERVERS | tr "%" "\n"`
-    do
-		if [ $i != $MASTER ]
+	##hadoop check
+	for i in `echo $SERVERS |cut -d "=" -f2 | tr "," "\n" | cut -d "," -f1`
+	do
+		HADOOP=$(ssh $i "grep '^export HADOOP_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
+		if [[ $? -eq 0 ]]
 		then
-			echo 'Copying Spark setup file on '$i'' | tee -a $log
-			scp ${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz @$i:${WORKDIR} | tee -a $log
-	    fi
-		
-		echo 'Unzipping Spark setup file on '$i'' | tee -a $log
-		ssh $i "tar xf spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz --gzip" | tee -a $log	
-		
-		echo 'Updating .bashrc file on '$i' with Spark variables '	
-		echo '#StartSparkEnv' >tmp_b
-		echo "export SPARK_HOME="${WORKDIR}"/spark-${sparkver}-bin-hadoop${hadoopver:0:3}" >>tmp_b
-		echo "export PATH=\$SPARK_HOME/bin:\$PATH">>tmp_b
-		echo '#StopSparkEnv'>>tmp_b
-			
-		scp tmp_b @$i:${WORKDIR}&>>/dev/null
-			
-		ssh $i "grep -q "SPARK_HOME" ~/.bashrc"
-		if [ $? -ne 0 ];
-		then
-			ssh $i "cat tmp_b>>$HOME/.bashrc"
-			ssh $i "rm tmp_b"
+			echo -e 'HADOOP setup found on '$i' at '$HADOOP'' | tee -a $log
 		else
-			ssh $i "sed -i '/#StartSparkEnv/,/#StopSparkEnv/ d' $HOME/.bashrc"
-			ssh $i "cat tmp_b>>$HOME/.bashrc"
-			ssh $i "rm tmp_b"
+			echo -e 'HADOOP setup not found on '$i', Please complete hadoop setup using hadoop-cluster-utils.' | tee -a $log
+			exit 1 
 		fi
-
-		ssh $i "source $HOME/.bashrc"
-		
 	done
-	rm -rf tmp_b
 	echo "---------------------------------------------" | tee -a $log
 	
-
-	## updating Slave file for Spark folder
-	source ${HOME}/.bashrc
-	echo 'Updating Slave file for Spark setup'| tee -a $log
-
-	cp ${SPARK_HOME}/conf/slaves.template ${SPARK_HOME}/conf/slaves
-	sed -i 's|localhost||g' ${SPARK_HOME}/conf/slaves
-	
-    for i in `echo $SERVERS | tr "%" "\n"`
-    do
-	  echo ${i} >>${SPARK_HOME}/conf/slaves
+	##Spark check
+	for i in `echo $SERVERS |cut -d "=" -f2 | tr "," "\n" | cut -d "," -f1`
+	do
+		SPARK=$(ssh $i "grep '^export SPARK_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
+		if [[ $? -eq 0 ]]
+		then
+			echo -e 'SPARK setup found on '$i' at '$SPARK'' | tee -a $log
+		else
+			echo -e 'SPARK setup not found on '$i', Please complete spark setup using hadoop-cluster-utils.' | tee -a $log
+			exit 1 
+		fi
 	done
 	
 	echo "---------------------------------------------" | tee -a $log
 	
-	#SPARK perf setup steps
+	##SPARK perf setup steps
 
-	if [ ! -d ${WORKDIR}/spark-perf ];
+	if [ -d ${WORKDIR}/spark-perf ];
 	then
-		 if curl --output /dev/null --silent --head --fail ${SPARK_PERF_GIT_URL}
-		 then
-			 git clone ${SPARK_PERF_GIT_URL} | tee -a $log
-			 echo "spark-perf cloning Done" | tee -a $log
-				 
-		 else
-			 echo 'This URL - '${SPARK_PERF_GIT_URL}' does not exist. Please check your url for Spark perf git repository.' | tee -a $log
-			 exit 1
-		 fi 
+	    echo -e 'Removing existing spark-perf folder - '${WORKDIR}'/spark-perf \n' | tee -a $log
+		rm -rf ${WORKDIR}/spark-perf &>/dev/null
 	fi
-
-	echo "Sourcing .bashrc file on localhost" | tee -a $log 
-	source $HOME/.bashrc
 	
-	#Config.py changes 
+    if curl --output /dev/null --silent --head --fail ${SPARK_PERF_GIT_URL}
+	then
+		 git clone ${SPARK_PERF_GIT_URL} | tee -a $log
+		 echo -e 
+		 echo -e 'spark-perf cloning done at - '${WORKDIR}'/spark-perf' | tee -a $log
+				 
+	else
+	     echo -e
+		 echo 'This URL - '${SPARK_PERF_GIT_URL}' does not exist. Please check url for Spark perf git repository.' | tee -a $log
+		 exit 1
+	fi 
+	
+    echo "---------------------------------------------" | tee -a $log
+	
+	source $HOME/.bashrc
+	##Config.py changes 
 
 	echo "Configuring changes in config.py file" | tee -a $log
-	cp ${WORKDIR}/spark-perf/config/config.py.template ${WORKDIR}/spark-perf/config/config.py
+	cp ${WORKDIR}/spark-perf/config/config.py.template ${WORKDIR}/spark-perf/config/config.py 
 	#Set spark home directory
-	sed -i 's|^DEFAULT_HOME.*|DEFAULT_HOME="'${SPARK_HOME}'"|g' ${WORKDIR}/spark-perf/config/config.py
-	
+	sed -i 's|^DEFAULT_HOME.*|DEFAULT_HOME="'${SPARK_HOME}'"|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|SPARK_HOME_DIR = "/root/spark"|SPARK_HOME_DIR = "'${SPARK_HOME}'"|g' ${WORKDIR}/spark-perf/config/config.py 
 	#Set Spark master
-	#sed -i 's|^SPARK_CLUSTER_URL.*|SPARK_CLUSTER_URL = "spark://%s:7077" % socket.gethostname()|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|^SPARK_CLUSTER_URL.*|SPARK_CLUSTER_URL = "spark://'${HOSTNAME}':7077"|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^SPARK_CLUSTER_URL.*|SPARK_CLUSTER_URL = "spark://'${HOSTNAME}':7077"|g' ${WORKDIR}/spark-perf/config/config.py 
 	
-	sed -i 's|^RUN_SPARK_TESTS.*|RUN_SPARK_TESTS = '${RUN_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|^PREP_SPARK_TESTS.*|PREP_SPARK_TESTS = '${PREP_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^RUN_SPARK_TESTS.*|RUN_SPARK_TESTS = '${RUN_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|^PREP_SPARK_TESTS.*|PREP_SPARK_TESTS = '${PREP_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
 
-	sed -i 's|^RUN_PYSPARK_TESTS.*|RUN_PYSPARK_TESTS = '${RUN_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|PREP_PYSPARK_TESTS.*|PREP_PYSPARK_TESTS = '${PREP_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^RUN_PYSPARK_TESTS.*|RUN_PYSPARK_TESTS = '${RUN_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|PREP_PYSPARK_TESTS.*|PREP_PYSPARK_TESTS = '${PREP_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
 
-	sed -i 's|RUN_STREAMING_TESTS.*|RUN_STREAMING_TESTS = '${RUN_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|PREP_STREAMING_TESTS.*|PREP_STREAMING_TESTS = '${PREP_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|RUN_STREAMING_TESTS.*|RUN_STREAMING_TESTS = '${RUN_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|PREP_STREAMING_TESTS.*|PREP_STREAMING_TESTS = '${PREP_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
 
-	sed -i 's|RUN_MLLIB_TESTS.*|RUN_MLLIB_TESTS = '${RUN_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|PREP_MLLIB_TESTS.*|PREP_MLLIB_TESTS = '${PREP_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
-	sed -i 's|RUN_PYTHON_MLLIB_TESTS.*|RUN_PYTHON_MLLIB_TESTS = '${RUN_PYTHON_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|RUN_MLLIB_TESTS.*|RUN_MLLIB_TESTS = '${RUN_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|PREP_MLLIB_TESTS.*|PREP_MLLIB_TESTS = '${PREP_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
+	sed -i 's|RUN_PYTHON_MLLIB_TESTS.*|RUN_PYTHON_MLLIB_TESTS = '${RUN_PYTHON_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py 
 
-	sed -i 's|^SCALE_FACTOR.*|SCALE_FACTOR = '${SCALE_FACTOR}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^SCALE_FACTOR.*|SCALE_FACTOR = '${SCALE_FACTOR}'|g' ${WORKDIR}/spark-perf/config/config.py 
 else
     echo "Config file does not exist. Please check README.md for installation steps." | tee -a $log
     exit 1
@@ -201,20 +145,24 @@ fi
 
 echo "---------------------------------------------" | tee -a $log	
 
-
 cd ${WORKDIR}/spark-perf
 
 #Running the spark-perf
 echo "Running the spark-perf benchmark" | tee -a $log
 ${WORKDIR}/spark-perf/bin/run | tee -a $log
 
-echo "---------------------------------------------" | tee -a $log
-echo "Copying results to RESULT directory in home"
-if [ ! -d ${HOME}/RESULT ];
+if [ ! -d ${PERFUTILS_DIR}/spark_perf_results ]
 then
-    mkdir ${HOME}/RESULT
+    mkdir ${PERFUTILS_DIR}/spark_perf_results  
 fi
 
-cp -r ${WORKDIR}/spark-perf/results/* ${HOME}/RESULT/.
+echo "---------------------------------------------" | tee -a $log
+
+cd ${WORKDIR}/spark-perf/result &>//dev/null
+current_time=$(date +"%Y.%m.%d.%S")
+zip ${PERFUTILS_DIR}/spark_perf_results/spark_perf_output_$current_time.zip ./* &>>/dev/null
+
+echo 'Copying results to '${PERFUTILS_DIR}'/spark_perf_results/spark_perf_output_'$current_time'.zip' | tee -a $log
+echo 'You can check results at location '${PERFUTILS_DIR}'/spark_perf_results and logs at location '${PERFUTILS_DIR}'/spark_perf_logs' | tee -a $log
 	
 

--- a/spark-perf/setup_sparkperf.sh
+++ b/spark-perf/setup_sparkperf.sh
@@ -1,0 +1,220 @@
+#!/bin/bash -l
+
+CURDIR=`pwd`            
+WORKDIR=${HOME}   
+
+current_time=$(date +"%Y.%m.%d.%S")
+
+if [ ! -d spark_perf_logs ];
+then
+    mkdir spark_perf_logs
+fi
+
+log=`pwd`/spark_perf_logs/spark_perf_$current_time.log
+
+echo -e | tee -a $log
+
+#check for prerequisites
+
+#Checking if JAVA_HOME set
+if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]
+then
+    echo JAVA_HOME found on MASTER, java executable in $JAVA_HOME | tee $log
+    echo "---------------------------------------------" | tee -a $log
+else
+    echo "JAVA_HOME not found in your environment, please set the JAVA_HOME variable in your environment then continue to run this script." | tee -a $log
+    exit 1 
+fi
+
+#Checking if below line commented in .bashrc
+grep '#case $- in' $HOME/.bashrc &>>/dev/null
+ if [ $? -ne 0 ]
+then
+    grep 'case $- in' $HOME/.bashrc &>>/dev/null
+	if [ $? -eq 0 ]
+	then 
+        echo 'Prerequisite not completed on Master. Please comment below lines in .bashrc file , also make sure same on slave machines' | tee -a $log
+        echo "# If not running interactively, don't do anything" | tee -a $log
+        echo "case \$- in" | tee -a $log
+        echo "*i*) ;;" | tee -a $log
+        echo "*) return;;" | tee -a $log
+        echo "esac" | tee -a $log
+	    exit 1
+	fi	
+fi
+
+##Checking if wget and curl installed or not, and getting installed if not
+
+if [ ! -x /usr/bin/wget ] ; then
+   echo "wget is not installed on Master, so getting installed" | tee -a $log
+   sudo apt-get install wget | tee -a $log
+else
+   echo "wget is already installed on Master" | tee -a $log
+fi
+
+if [ ! -x /usr/bin/curl ] ; then
+   echo "curl is not installed on Master, so getting installed" | tee -a $log
+   sudo apt-get install curl | tee -a $log
+else
+   echo "curl is already installed on Master" | tee -a $log
+fi
+
+#checking if config.sh file is created in required format
+
+if [ -f ${CURDIR}/config.sh ]; 
+then
+    ## First time permission set for config.sh file
+    chmod +x ${CURDIR}/config.sh
+    source ${CURDIR}/config.sh
+ 
+    ## Checking config file for all required fields
+  
+    { cat ${CURDIR}/config.sh; echo; } | while read -r line; do
+      if [[ $line =~ "=" ]] ;
+      then
+          confvalue=`echo $line |grep = | cut -d "=" -f2`
+          if [[ -z "$confvalue" ]];
+          then
+              echo "Configuration value not set properly for $line, please check config.sh file" | tee -a $log
+              exit 1
+          fi
+      fi
+    done
+	
+	SERVERS=$SLAVES
+	
+	cd ${WORKDIR}
+	
+	# Spark setup steps
+    if [ ! -f ${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz ];
+    then
+        if curl --output /dev/null --silent --head --fail $SPARK_URL
+        then
+	        echo 'SPARK file Downloading on Master - '$MASTER'' | tee -a $log
+            wget $SPARK_URL | tee -a $log
+        else 
+            echo 'This URL '${SPARK_URL}' does not exist. Please check your spark version then continue to run this script.' | tee -a $log
+        exit 1
+        fi 
+	 
+    echo "***********************************************"
+    fi
+	
+	for i in `echo $SERVERS | tr "%" "\n"`
+    do
+		if [ $i != $MASTER ]
+		then
+			echo 'Copying Spark setup file on '$i'' | tee -a $log
+			scp ${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz @$i:${WORKDIR} | tee -a $log
+	    fi
+		
+		echo 'Unzipping Spark setup file on '$i'' | tee -a $log
+		ssh $i "tar xf spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz --gzip" | tee -a $log	
+		
+		echo 'Updating .bashrc file on '$i' with Spark variables '	
+		echo '#StartSparkEnv' >tmp_b
+		echo "export SPARK_HOME="${WORKDIR}"/spark-${sparkver}-bin-hadoop${hadoopver:0:3}" >>tmp_b
+		echo "export PATH=\$SPARK_HOME/bin:\$PATH">>tmp_b
+		echo '#StopSparkEnv'>>tmp_b
+			
+		scp tmp_b @$i:${WORKDIR}&>>/dev/null
+			
+		ssh $i "grep -q "SPARK_HOME" ~/.bashrc"
+		if [ $? -ne 0 ];
+		then
+			ssh $i "cat tmp_b>>$HOME/.bashrc"
+			ssh $i "rm tmp_b"
+		else
+			ssh $i "sed -i '/#StartSparkEnv/,/#StopSparkEnv/ d' $HOME/.bashrc"
+			ssh $i "cat tmp_b>>$HOME/.bashrc"
+			ssh $i "rm tmp_b"
+		fi
+
+		ssh $i "source $HOME/.bashrc"
+		
+	done
+	rm -rf tmp_b
+	echo "---------------------------------------------" | tee -a $log
+	
+
+	## updating Slave file for Spark folder
+	source ${HOME}/.bashrc
+	echo 'Updating Slave file for Spark setup'| tee -a $log
+
+	cp ${SPARK_HOME}/conf/slaves.template ${SPARK_HOME}/conf/slaves
+	sed -i 's|localhost||g' ${SPARK_HOME}/conf/slaves
+	
+    for i in `echo $SERVERS | tr "%" "\n"`
+    do
+	  echo ${i} >>${SPARK_HOME}/conf/slaves
+	done
+	
+	echo "---------------------------------------------" | tee -a $log
+	
+	#SPARK perf setup steps
+
+	if [ ! -d ${WORKDIR}/spark-perf ];
+	then
+		 if curl --output /dev/null --silent --head --fail ${SPARK_PERF_GIT_URL}
+		 then
+			 git clone ${SPARK_PERF_GIT_URL} | tee -a $log
+			 echo "spark-perf cloning Done" | tee -a $log
+				 
+		 else
+			 echo 'This URL - '${SPARK_PERF_GIT_URL}' does not exist. Please check your url for Spark perf git repository.' | tee -a $log
+			 exit 1
+		 fi 
+	fi
+
+	echo "Sourcing .bashrc file on localhost" | tee -a $log 
+	source $HOME/.bashrc
+	
+	#Config.py changes 
+
+	echo "Configuring changes in config.py file" | tee -a $log
+	cp ${WORKDIR}/spark-perf/config/config.py.template ${WORKDIR}/spark-perf/config/config.py
+	#Set spark home directory
+	sed -i 's|^DEFAULT_HOME.*|DEFAULT_HOME="'${SPARK_HOME}'"|g' ${WORKDIR}/spark-perf/config/config.py
+	
+	#Set Spark master
+	#sed -i 's|^SPARK_CLUSTER_URL.*|SPARK_CLUSTER_URL = "spark://%s:7077" % socket.gethostname()|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^SPARK_CLUSTER_URL.*|SPARK_CLUSTER_URL = "spark://'${HOSTNAME}':7077"|g' ${WORKDIR}/spark-perf/config/config.py
+	
+	sed -i 's|^RUN_SPARK_TESTS.*|RUN_SPARK_TESTS = '${RUN_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|^PREP_SPARK_TESTS.*|PREP_SPARK_TESTS = '${PREP_SPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+
+	sed -i 's|^RUN_PYSPARK_TESTS.*|RUN_PYSPARK_TESTS = '${RUN_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|PREP_PYSPARK_TESTS.*|PREP_PYSPARK_TESTS = '${PREP_PYSPARK_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+
+	sed -i 's|RUN_STREAMING_TESTS.*|RUN_STREAMING_TESTS = '${RUN_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|PREP_STREAMING_TESTS.*|PREP_STREAMING_TESTS = '${PREP_STREAMING_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+
+	sed -i 's|RUN_MLLIB_TESTS.*|RUN_MLLIB_TESTS = '${RUN_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|PREP_MLLIB_TESTS.*|PREP_MLLIB_TESTS = '${PREP_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+	sed -i 's|RUN_PYTHON_MLLIB_TESTS.*|RUN_PYTHON_MLLIB_TESTS = '${RUN_PYTHON_MLLIB_TESTS}'|g' ${WORKDIR}/spark-perf/config/config.py
+
+	sed -i 's|^SCALE_FACTOR.*|SCALE_FACTOR = '${SCALE_FACTOR}'|g' ${WORKDIR}/spark-perf/config/config.py
+else
+    echo "Config file does not exist. Please check README.md for installation steps." | tee -a $log
+    exit 1
+fi
+
+echo "---------------------------------------------" | tee -a $log	
+
+
+cd ${WORKDIR}/spark-perf
+
+#Running the spark-perf
+echo "Running the spark-perf benchmark" | tee -a $log
+${WORKDIR}/spark-perf/bin/run | tee -a $log
+
+echo "---------------------------------------------" | tee -a $log
+echo "Copying results to RESULT directory in home"
+if [ ! -d ${HOME}/RESULT ];
+then
+    mkdir ${HOME}/RESULT
+fi
+
+cp -r ${WORKDIR}/spark-perf/results/* ${HOME}/RESULT/.
+	
+

--- a/spark-perf/setup_sparkperf.sh
+++ b/spark-perf/setup_sparkperf.sh
@@ -158,9 +158,9 @@ fi
 
 echo "---------------------------------------------" | tee -a $log
 
-cd ${WORKDIR}/spark-perf/result &>//dev/null
+cd ${WORKDIR}/spark-perf/results &>//dev/null
 current_time=$(date +"%Y.%m.%d.%S")
-zip ${PERFUTILS_DIR}/spark_perf_results/spark_perf_output_$current_time.zip ./* &>>/dev/null
+zip -r ${PERFUTILS_DIR}/spark_perf_results/spark_perf_output_$current_time.zip ./* &>>/dev/null
 
 echo 'Copying results to '${PERFUTILS_DIR}'/spark_perf_results/spark_perf_output_'$current_time'.zip' | tee -a $log
 echo 'You can check results at location '${PERFUTILS_DIR}'/spark_perf_results and logs at location '${PERFUTILS_DIR}'/spark_perf_logs' | tee -a $log


### PR DESCRIPTION
Readme -
•	Removed duplicate part from Hadoop-cluster-utils setup and mentioned Hadoop-cluster-utils setup as prerequisite only.

Autogen_sparkperf.sh -

•	Using existing Hadoop &  spark setup information to get the master and slave machine details. So no user input required for this , in script now.
•	Renamed config.sh to config
•	As discussed, added check to pick different repositories for spark-perf benchmark according to spark version 
                        i.e. for spark version >= 2 -- https://github.com/a-roberts/spark-perf
                                       spark version <2 -- https://github.com/databricks/spark-perf.git

Setup_sparkperf.sh -

•	Removed spark setup part from script as it will done through hadop-cluster-utils already.
•	Added check if zip is already installed or not, as it will be required to zip the end result files.
•	Added check to verify Hadoop and spark variables on all machines (master + slaves)
•	Added check to confirm if at least 1 test selected for run in config.
•	Now removing spark-perf directory every run if it already exists and then cloning it every time.
•	Moving end output and logs in zip format to spark-perf setup directory
